### PR TITLE
fix bug of nbt_doPLI.m

### DIFF
--- a/Biomarkers/nbt_PLI/nbt_doPLI.m
+++ b/Biomarkers/nbt_PLI/nbt_doPLI.m
@@ -34,7 +34,7 @@ phaseSignal = angle(hilbert(Signal));
 
 for i = 1:(numChannels-1)
     for m = (i+1):numChannels
-        PLIobject.pliVal(i,m) = abs(mean(sign(phaseSignal(:,i)-phaseSignal(:,m))));
+        PLIobject.pliVal(i,m) = abs(mean(sign(sin(phaseSignal(:,i)-phaseSignal(:,m))));
     end
 end
 


### PR DESCRIPTION
The instantaneous phase computed with angle(hilbert(Signal)) is between
-pi and pi  , therefore, the phase difference range from -2pi to 2pi ,
but the Phase Lag Index is defined on a phase difference in [-pi,pi]. So
the phase difference must be project to [-pi , pi  ]  or compute the PLI
use  abs(mean(sign(sin(phaseSignal(:,i)-phaseSignal(:,m)))).   (Stam.
et.al , 2007)
